### PR TITLE
feat: simplify WTE and ECU parameter configuration

### DIFF
--- a/src/geoenvo/data_sources/ecological_coastal_units.py
+++ b/src/geoenvo/data_sources/ecological_coastal_units.py
@@ -50,7 +50,7 @@ class EcologicalCoastalUnits(DataSource):
         `https://doi.org/10.5066/P9HWHSPU <https://doi.org/10.5066/P9HWHSPU>`_.
     """
 
-    def __init__(self):
+    def __init__(self, buffer: float = None):
         """
         Initializes the EcologicalCoastalUnits data source with default
         properties.
@@ -71,7 +71,7 @@ class EcologicalCoastalUnits(DataSource):
             "Chlorophyll": None,
             "CSU_Descriptor": None,
         }
-        self._buffer = None
+        self._buffer = buffer
 
     @property
     # pylint: disable=duplicate-code

--- a/src/geoenvo/data_sources/world_terrestrial_ecosystems.py
+++ b/src/geoenvo/data_sources/world_terrestrial_ecosystems.py
@@ -50,7 +50,7 @@ class WorldTerrestrialEcosystems(DataSource):
         <https://doi.org/10.5066/P9DO61LP>`_.
     """
 
-    def __init__(self):
+    def __init__(self, grid_size: float = None):
         """
         Initializes the WorldTerrestrialEcosystems data source with default
         properties.
@@ -67,7 +67,7 @@ class WorldTerrestrialEcosystems(DataSource):
             "ClassName": None,
         }
 
-        self._grid_size = None
+        self._grid_size = grid_size
 
     @property
     # pylint: disable=duplicate-code

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from geoenvo.utilities import EnvironmentDataModel
 @pytest.fixture()
 def use_mock():
     """Use mock data for testing purposes."""
-    return False  # Change this to False for real HTTP requests and data
+    return True  # Change this to False for real HTTP requests and data
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from geoenvo.utilities import EnvironmentDataModel
 @pytest.fixture()
 def use_mock():
     """Use mock data for testing purposes."""
-    return True  # Change this to False for real HTTP requests and data
+    return False  # Change this to False for real HTTP requests and data
 
 
 @pytest.fixture


### PR DESCRIPTION
Enable initialization of the `grid_size` and `buffer` attributes for the World Terrestrial Ecosystems (WTE) and Ecological Coastal Units (ECU) data sources, respectively, to `None`. This improves the visibility of these parameters in class docstrings, enhancing user understanding and simplifying object initialization.